### PR TITLE
Reorganize the structure

### DIFF
--- a/index.rst
+++ b/index.rst
@@ -12,25 +12,30 @@ Electro-optical setup
 .. include::   sections/run7Changes.rst
 .. include::   sections/projectorSpots.rst
 .. include::   sections/darkCurrent.rst
+
 ----------------------------------
 Reverification
 ----------------------------------
 .. include::   sections/baselineCharacterization.rst
+
 ----------------------------------
 Camera Optimization
------------------------------------
+----------------------------------
 .. include::   sections/persistenceOptimization.rst
 .. include::   sections/sequencerOptimization.rst
 .. include::   sections/thermalOptimization.rst
+
 -----------------------------------
 Characterization & Camera stability
 -----------------------------------
 The final result of B protocol and PTC need to be presented here.
+
 .. include::   sections/finalCharacterization.rst
 .. include::   sections/guiderOperation.rst
 .. include::   sections/defectStability.rst
 .. include::   sections/biasStability.rst
 .. include::   sections/gainStability.rst
+
 ----------------------------------
 Sensor features
 ----------------------------------
@@ -39,6 +44,7 @@ Sensor features
 .. include::   sections/vampirePixels.rst
 .. include::   sections/serialRemnants.rst
 .. include::   sections/phosphorescence.rst
+
 ----------------------------------
 Conclusions
 ----------------------------------

--- a/index.rst
+++ b/index.rst
@@ -13,19 +13,21 @@ Electro-optical setup
 .. include::   sections/projectorSpots.rst
 .. include::   sections/darkCurrent.rst
 --------------------------------
+Reverification
+--------------------------------
+.. include::   sections/baselineCharacterization.rst
+--------------------------------
 Camera Optimization
 --------------------------------
 .. include::   sections/persistenceOptimization.rst
 .. include::   sections/sequencerOptimization.rst
 .. include::   sections/thermalOptimization.rst
 --------------------------------
-Characterization
+Characterization & Camera stability
 --------------------------------
-.. include::   sections/baselineCharacterization.rst
+The final result of B protocol and PTC need to be presented here.
+.. include::   sections/finalCharacterization.rst
 .. include::   sections/guiderOperation.rst
---------------------------------
-Camera stability
---------------------------------
 .. include::   sections/defectStability.rst
 .. include::   sections/biasStability.rst
 .. include::   sections/gainStability.rst

--- a/index.rst
+++ b/index.rst
@@ -6,26 +6,23 @@ LSST Camera Electro-Optical Test Results
 
    'This note collects results from the LSST Camera electro-optical testing prior to installation on the TMA. We describe the CCD and Focal Plane optimization and the resulting default settings. Results from eo_pipe are shown for standard runs such as B-protocols, Dense and SuperDense PTCs, gain stability, OpSim runs of Darks, and Darks with variable delays. We also describe features such as e2v Persistence, ITL phosphorescence in coffee stains, remnant charge near Serial register following saturated images, vampire pixels, ITL dips, and others.
 
-
 --------------------------------
 Electro-optical setup
 --------------------------------
 .. include::   sections/run7Changes.rst
 .. include::   sections/projectorSpots.rst
-.. include::   sections/fcsDevelopment.rst
---------------------------------
-Characterization
---------------------------------
 .. include::   sections/darkCurrent.rst
-.. include::   sections/baselineCharacterization.rst
-.. include::   sections/guiderOperation.rst
-.. include::   sections/treeRings.rst
 --------------------------------
 Camera Optimization
 --------------------------------
-.. include::   sections/sequencerOptimization.rst
 .. include::   sections/persistenceOptimization.rst
+.. include::   sections/sequencerOptimization.rst
 .. include::   sections/thermalOptimization.rst
+--------------------------------
+Characterization
+--------------------------------
+.. include::   sections/baselineCharacterization.rst
+.. include::   sections/guiderOperation.rst
 --------------------------------
 Camera stability
 --------------------------------
@@ -35,6 +32,7 @@ Camera stability
 --------------------------------
 Sensor features
 --------------------------------
+.. include::   sections/treeRings.rst
 .. include::   sections/ITLDips.rst
 .. include::   sections/vampirePixels.rst
 .. include::   sections/serialRemnants.rst

--- a/index.rst
+++ b/index.rst
@@ -6,42 +6,42 @@ LSST Camera Electro-Optical Test Results
 
    'This note collects results from the LSST Camera electro-optical testing prior to installation on the TMA. We describe the CCD and Focal Plane optimization and the resulting default settings. Results from eo_pipe are shown for standard runs such as B-protocols, Dense and SuperDense PTCs, gain stability, OpSim runs of Darks, and Darks with variable delays. We also describe features such as e2v Persistence, ITL phosphorescence in coffee stains, remnant charge near Serial register following saturated images, vampire pixels, ITL dips, and others.
 
---------------------------------
+----------------------------------
 Electro-optical setup
---------------------------------
+----------------------------------
 .. include::   sections/run7Changes.rst
 .. include::   sections/projectorSpots.rst
 .. include::   sections/darkCurrent.rst
---------------------------------
+----------------------------------
 Reverification
---------------------------------
+----------------------------------
 .. include::   sections/baselineCharacterization.rst
---------------------------------
+----------------------------------
 Camera Optimization
---------------------------------
+-----------------------------------
 .. include::   sections/persistenceOptimization.rst
 .. include::   sections/sequencerOptimization.rst
 .. include::   sections/thermalOptimization.rst
---------------------------------
+-----------------------------------
 Characterization & Camera stability
---------------------------------
+-----------------------------------
 The final result of B protocol and PTC need to be presented here.
 .. include::   sections/finalCharacterization.rst
 .. include::   sections/guiderOperation.rst
 .. include::   sections/defectStability.rst
 .. include::   sections/biasStability.rst
 .. include::   sections/gainStability.rst
---------------------------------
+----------------------------------
 Sensor features
---------------------------------
+----------------------------------
 .. include::   sections/treeRings.rst
 .. include::   sections/ITLDips.rst
 .. include::   sections/vampirePixels.rst
 .. include::   sections/serialRemnants.rst
 .. include::   sections/phosphorescence.rst
---------------------------------
+----------------------------------
 Conclusions
---------------------------------
+----------------------------------
 .. include::   sections/run7OperatingParameters.rst
 .. include::   sections/recordRuns.rst
 

--- a/sections/finalCharacterization.rst
+++ b/sections/finalCharacterization.rst
@@ -1,0 +1,1 @@
+B protocol result and PTC result needs to be summarized here.


### PR DESCRIPTION
I'd like to reorganize the structure to focus on the EO testing result (and also follow the abstract). Some of hardware related sections have been ommitted.
Also, it'd be good to present the optimization first and then the result comes after. 